### PR TITLE
docs: change server issue page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Configure the intelephense language server by accessing `Preferences > Package S
 
 ### Server issues
 
-Language server related bugs report [here](https://github.com/bmewburn/intelephense-docs).
+Language server related bugs report [here](https://github.com/bmewburn/vscode-intelephense).
 
 > NOTE: This plugin wouldn't be possible if intelephense didn't exist. So if you find it useful, support the [man](https://github.com/bmewburn) who took the time to make it. Star it on [github](https://github.com/bmewburn/intelephense-docs), or show you appreciation by buying the [licence](https://intelephense.com/).


### PR DESCRIPTION
https://github.com/bmewburn/vscode-intelephense is active.
https://github.com/bmewburn/intelephense-docs isn't.

I actually always report to the "vscode" repo such as https://github.com/bmewburn/vscode-intelephense/issues/1297.
