### PR TITLE
feat: enable in file-less views

### DIFF
--- a/LSP-intelephense.sublime-settings
+++ b/LSP-intelephense.sublime-settings
@@ -14,6 +14,7 @@
 			"feature_selector": "source.php",
 		},
 	],
+	"schemes": ["file", "buffer"],
 	"auto_complete_selector": "punctuation.accessor | punctuation.definition.variable | punctuation.separator.namespace | punctuation.definition.tag.begin",
 	"initializationOptions": {
 		"clearCache": false,


### PR DESCRIPTION
Seems to work fine in file-less scratch views. No need for `res` as PHP files aren't in .sublime-package files.