### PR TITLE
refactor: migrate to LspPlugin

### DIFF
--- a/LSP-intelephense.sublime-settings
+++ b/LSP-intelephense.sublime-settings
@@ -1,5 +1,4 @@
 {
-	"schemes": ["file", "buffer"],
 	"auto_complete_selector": "punctuation.accessor | punctuation.definition.variable | punctuation.separator.namespace | punctuation.definition.tag.begin",
 	"initialization_options": {
 		"clearCache": false,
@@ -260,6 +259,13 @@
 		// The maximum call depth to follow when analyzing throw expressions. Defaults to `0`, which limits analysis to the current function. Higher values can have a negative impact on performance.
 		"intelephense.throwDepth": 0,
 	},
+	// The path to the server binary used to start the language server.
+	// Use `auto` for the package to manage (install/update) the server automatically.
+	// NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.
+	// WARNING: Override at your own risk - using a custom binary can cause compatibility issues with server settings.
+	"server_path": "auto",
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
+	"schemes": ["file", "buffer"],
 	"selector": "embedding.php",
 	"priority_selector": "source.php",
 }

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ ci-base-cmd = uv run --dev
 
 .PHONY: ci-check
 ci-check:
-	@if [ -n "$$CI" ]; then \
-		echo "========== check: mypy =========="; \
-		$(ci-base-cmd) mypy -p plugin; \
-	fi
+ifdef CI
+	@echo "========== check: mypy =========="
+	$(ci-base-cmd) mypy -p plugin
+endif
 	@echo "========== check: ruff (lint) =========="
 	$(ci-base-cmd) ruff check --diff .
 	@echo "========== check: ruff (format) =========="

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ ci-base-cmd = uv run --dev
 
 .PHONY: ci-check
 ci-check:
-# 	@echo "========== check: mypy =========="
-# 	$(ci-base-cmd) mypy -p plugin
+	@if [ -n "$$CI" ]; then \
+		echo "========== check: mypy =========="; \
+		$(ci-base-cmd) mypy -p plugin; \
+	fi
 	@echo "========== check: ruff (lint) =========="
 	$(ci-base-cmd) ruff check --diff .
 	@echo "========== check: ruff (format) =========="

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ ci-base-cmd = uv run --dev
 
 .PHONY: ci-check
 ci-check:
-	@echo "========== check: mypy =========="
-	$(ci-base-cmd) mypy -p plugin
+# 	@echo "========== check: mypy =========="
+# 	$(ci-base-cmd) mypy -p plugin
 	@echo "========== check: ruff (lint) =========="
 	$(ci-base-cmd) ruff check --diff .
 	@echo "========== check: ruff (format) =========="

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -15,9 +15,10 @@ __all__ = (
 
 def plugin_loaded() -> None:
     """Executed when this plugin is loaded."""
+    LspIntelephensePlugin.register()
     LspIntelephensePlugin.setup()
 
 
 def plugin_unloaded() -> None:
     """Executed when this plugin is unloaded."""
-    LspIntelephensePlugin.cleanup()
+    LspIntelephensePlugin.unregister()

--- a/plugin/client.py
+++ b/plugin/client.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from pathlib import Path
 from typing import Any, final
 
 import jmespath
 import sublime
-from LSP.plugin import ClientConfig, DottedDict, notification_handler
-from lsp_utils import NpmClientHandler
-from sublime_lib import ActivityIndicator
+from LSP.plugin import LspPlugin, OnPreStartContext, notification_handler
+from lsp_utils import NodeManager
+from sublime_lib import ActivityIndicator, ResourcePath
 from typing_extensions import override
 
 from .constants import PACKAGE_NAME
@@ -18,13 +19,27 @@ from .template import load_string_template
 
 
 @final
-class LspIntelephensePlugin(NpmClientHandler):
-    package_name = PACKAGE_NAME
-    server_directory = "language-server"
-    server_binary_path = os.path.join(server_directory, "node_modules", "intelephense", "lib", "intelephense.js")
-
+class LspIntelephensePlugin(LspPlugin):
     server_version = ""
     """The version of the language server."""
+
+    @classmethod
+    @override
+    def on_pre_start_async(cls, context: OnPreStartContext) -> None:
+        package_name = cls.plugin_storage_path.name
+        NodeManager.on_pre_start_async(
+            context,
+            cls.plugin_storage_path,
+            ResourcePath("Packages", package_name, "language-server"),
+            Path("node_modules", "intelephense", "lib", "intelephense.js"),
+            node_version_requirement=">=14",
+        )
+        context.variables.update({
+            "cache_path": sublime.cache_path(),
+            "home": os.path.expanduser("~"),
+            "package_storage": str(cls.plugin_storage_path),
+            "temp_dir": tempfile.gettempdir(),
+        })
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -32,47 +47,8 @@ class LspIntelephensePlugin(NpmClientHandler):
         self._activity_indicator: ActivityIndicator | None = None
 
     @override
-    @classmethod
-    def required_node_version(cls) -> str:
-        """
-        Testing playground at https://semver.npmjs.com
-        And `0.0.0` means "no restrictions".
-        """
-        return ">=14"
-
-    @override
-    @classmethod
-    def is_applicable(cls, view: sublime.View, config: ClientConfig) -> bool:
-        return bool(
-            super().is_applicable(view, config)
-            # REPL views (https://github.com/sublimelsp/LSP-pyright/issues/343)
-            and not view.settings().get("repl")
-        )
-
-    @override
-    @classmethod
-    def setup(cls) -> None:
-        super().setup()
-
-        cls.server_version = cls.parse_server_version()
-
-    @override
-    def on_settings_changed(self, settings: DottedDict) -> None:
-        super().on_settings_changed(settings)
-
+    def on_initialized_async(self) -> None:
         self.update_status_bar_text()
-
-    @override
-    @classmethod
-    def get_additional_variables(cls) -> dict[str, str]:
-        variables = super().get_additional_variables() or {}
-        variables.update({
-            "cache_path": sublime.cache_path(),
-            "home": os.path.expanduser("~"),
-            "package_storage": cls.package_storage(),
-            "temp_dir": tempfile.gettempdir(),
-        })
-        return variables
 
     # ---------------- #
     # message handlers #
@@ -80,7 +56,7 @@ class LspIntelephensePlugin(NpmClientHandler):
 
     @notification_handler("indexingStarted")
     def handle_indexing_started(self, params: None) -> None:
-        self._start_indicator(f"{self.package_name}: Indexing...")
+        self._start_indicator(f"{PACKAGE_NAME}: Indexing...")
 
     @notification_handler("indexingEnded")
     def handle_indexing_ended(self, params: None) -> None:
@@ -108,6 +84,10 @@ class LspIntelephensePlugin(NpmClientHandler):
             except Exception as e:
                 log_warning(f'Invalid "statusText" template: {e}')
         session.set_config_status_async(rendered_text)
+
+    @classmethod
+    def setup(cls) -> None:
+        cls.server_version = cls.parse_server_version()
 
     @classmethod
     def parse_server_version(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ ignore_missing_imports = true
 
 [tool.pyright]
 pythonVersion = '3.8'
+typeCheckingMode = 'standard'
 
 [tool.ruff]
 preview = true

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,6 +10,11 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
+                "server_path": {
+                  "type": "string",
+                  "default": "auto",
+                  "markdownDescription": "The path to the server binary to use for starting the language server. Use `auto` for the package to manage (install/update) server automatically.\n\n> [!NOTE]\n> Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.\n\n> [!WARNING]\n> Using custom binary could result in package settings not matching what server supports."
+                },
                 "initialization_options": {
                   "additionalProperties": false,
                   "properties": {

--- a/templates/sublime-package.jinja.json
+++ b/templates/sublime-package.jinja.json
@@ -10,6 +10,11 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
+                "server_path": {
+                  "type": "string",
+                  "default": "auto",
+                  "markdownDescription": "The path to the server binary to use for starting the language server. Use `auto` for the package to manage (install/update) server automatically.\n\n> [!NOTE]\n> Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.\n\n> [!WARNING]\n> Using custom binary could result in package settings not matching what server supports."
+                },
                 "initialization_options": {
                   "additionalProperties": false,
                   "properties": {

--- a/templates/sublime-settings.jinja.json
+++ b/templates/sublime-settings.jinja.json
@@ -1,5 +1,4 @@
 {
-	"schemes": ["file", "buffer"],
 	"auto_complete_selector": "punctuation.accessor | punctuation.definition.variable | punctuation.separator.namespace | punctuation.definition.tag.begin",
 	"initialization_options": {
 		"clearCache": false,
@@ -13,6 +12,13 @@
 	"settings": {
 		{{ settings | indent('\t\t') }}
 	},
+	// The path to the server binary used to start the language server.
+	// Use `auto` for the package to manage (install/update) the server automatically.
+	// NOTE: Change this instead of directly updating `command` - the `${server_path}` variable is dynamically resolved based on this setting.
+	// WARNING: Override at your own risk - using a custom binary can cause compatibility issues with server settings.
+	"server_path": "auto",
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
+	"schemes": ["file", "buffer"],
 	"selector": "embedding.php",
 	"priority_selector": "source.php",
 }


### PR DESCRIPTION
All packages are being migrated to [LspPlugin](https://lsp.sublimetext.io/migrating_to_lsp_plugin/) so that we can remove `AbstractPlugin`/`NpmClientHandler`.